### PR TITLE
BACKLOG-15216: Add check to skip file reference that is no longer there

### DIFF
--- a/site-builder/src/main/java/org/jahia/modules/sitebuilder/taglibs/functions/PageOverrideFunctions.java
+++ b/site-builder/src/main/java/org/jahia/modules/sitebuilder/taglibs/functions/PageOverrideFunctions.java
@@ -30,6 +30,9 @@ public final class PageOverrideFunctions {
 
         JCRValueWrapper[] values = ctxNode.getProperty(propName).getValues();
         for (JCRValueWrapper v : values) {
+            // reference still there but file no longer exists
+            if (v == null || v.getNode() == null) continue;
+
             String url = v.getNode().getUrl();
             if (StringUtils.isNotEmpty(url) && isFileType(fileType, url)) {
                 urls.add(url);

--- a/site-builder/src/test/java/org/jahia/modules/sitebuilder/taglibs/functions/PageOverrideFunctionsTest.java
+++ b/site-builder/src/test/java/org/jahia/modules/sitebuilder/taglibs/functions/PageOverrideFunctionsTest.java
@@ -78,4 +78,18 @@ public class PageOverrideFunctionsTest {
         }
     }
 
+    /**
+     * Happens when a file has been deleted but the prop reference is still there.
+     */
+    @Test public void testPageOverrideNullValueNode() {
+        try {
+            ctxNode.setProperty("nullNodeProp", new MockValue[] { new MockValue(null) });
+            List<String> urls = PageOverrideFunctions.getPageOverrides(
+                    ctxNode, "nullNodeProp", FileType.JAVASCRIPT);
+            Assert.assertEquals(urls.size(), 0);
+        } catch (RepositoryException e) {
+            Assert.fail("unexpected exception");
+        }
+    }
+
 }

--- a/site-builder/src/test/java/org/jahia/modules/sitebuilder/taglibs/mocks/MockValue.java
+++ b/site-builder/src/test/java/org/jahia/modules/sitebuilder/taglibs/mocks/MockValue.java
@@ -48,7 +48,15 @@ public class MockValue implements JCRValueWrapper {
 
     private static Logger log = LoggerFactory.getLogger(MockValue.class);
 
-    MockNode node = new MockNode();
+    MockNode node = null;
+
+    public MockValue() {
+        this(new MockNode());
+    }
+
+    public MockValue(MockNode n) {
+        this.node = n;
+    }
 
     @Override public JCRNodeWrapper getNode() throws ValueFormatException, IllegalStateException, RepositoryException {
        return node;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15216

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Added check for when file reference is still there but the file node itself no longer exists.

## Tests

The following are included in this PR
- [x] Unit Tests (Most changes _should_ have unit tests)
