### PR TITLE
BACKLOG-15206: Fix missing translation EN, FR, DE

### DIFF
--- a/page-builder-components/src/main/resources/resources/page-builder-components_de.properties
+++ b/page-builder-components/src/main/resources/resources/page-builder-components_de.properties
@@ -2,7 +2,7 @@
 #Fri Dec 11 21:48:52 UTC 2020
 jnt_htmlCodeAsFile.sourceCode=sourceCode
 jnt_htmlCodeAsFile.sourceFile=sourceFile
-jmix_pageBuilderComponentMixin=Page Builder Components
-jnt_htmlCodeAsFile=HTML-Code (as datei)
+jmix_pageBuilderComponentMixin=Seiten-Ersteller Komponente
+jnt_htmlCodeAsFile=HTML-Code (datei)
 jnt_htmlCodeAsText.sourceCode=sourceCode
-jnt_htmlCodeAsText=HTML-Code (as text)
+jnt_htmlCodeAsText=HTML-Code (text)

--- a/page-builder-components/src/main/resources/resources/page-builder-components_en.properties
+++ b/page-builder-components/src/main/resources/resources/page-builder-components_en.properties
@@ -3,6 +3,6 @@
 jnt_htmlCodeAsFile.sourceCode=Source code
 jnt_htmlCodeAsFile.sourceFile=Html file
 jmix_pageBuilderComponentMixin=Page Builder Components
-jnt_htmlCodeAsFile=HTML code (as file)
+jnt_htmlCodeAsFile=HTML code (file)
 jnt_htmlCodeAsText.sourceCode=Html source code
-jnt_htmlCodeAsText=HTML code (as text)
+jnt_htmlCodeAsText=HTML code (text)

--- a/page-builder-components/src/main/resources/resources/page-builder-components_fr.properties
+++ b/page-builder-components/src/main/resources/resources/page-builder-components_fr.properties
@@ -2,7 +2,7 @@
 #Fri Dec 11 21:48:52 UTC 2020
 jnt_htmlCodeAsFile.sourceCode=sourceCode
 jnt_htmlCodeAsFile.sourceFile=sourceFile
-jmix_pageBuilderComponentMixin=Page Builder Components
-jnt_htmlCodeAsFile=Code HTML (as fichier)
+jmix_pageBuilderComponentMixin=Composant de création de page
+jnt_htmlCodeAsFile=Code HTML (fichier)
 jnt_htmlCodeAsText.sourceCode=sourceCode
-jnt_htmlCodeAsText=Code HTML (as texte)
+jnt_htmlCodeAsText=Code HTML (texte)


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-15206

## Description
Fix missing translation for FR, EN, and DE

## Tests
Steps:

1. Install Site builder and Page Builder Components modules
2. Create site using the site-builder template and include the Page Builder Component modules
3. Change root user "Preferred Language" to the desired language (i.e FR or DE)
4. Navigate back to Page Composer and click on the Any Content button. You should see a new droppable called Seiten-Ersteller Komponente (DE) / Composant de création de page (FR)
5. Click on the down arrow to show the different page builder components: Code HTML (fichier) / Code HTML (texte) for FR and HTML-Code (datei) / HTML-Code (text) for DE


## Checklist


