### PR TITLE
BACKLOG-15333: Fix current page classes for sub-pages

### DIFF
--- a/site-builder/src/main/resources/sbnt_starterNavMenu/html/starterNavMenu.jsp
+++ b/site-builder/src/main/resources/sbnt_starterNavMenu/html/starterNavMenu.jsp
@@ -28,19 +28,17 @@
     <c:forEach var="node" items="${navPages}">
         <c:set var="children" value="${jcr:getChildrenOfType(node, 'jnt:page')}"/>
         <c:set var="showLvl2Pages" value="${(not empty children) && currentNode.properties['showLvl2Pages'].boolean}"/>
-        <c:set var="lvl1classes" value="${currentNode.properties['lvl1ItemClasses']}
-            ${ (currentPagePath eq node.path) ? currentNode.properties['currentPageClasses'] : ''}
-            ${ showLvl2Pages ? currentNode.properties['hasSubpagesClasses'] : '' }"/>
 
-        <${liTag} class="${lvl1classes}">
+        <${liTag} class="${currentNode.properties['lvl1ItemClasses']}${' '}
+            ${ (currentPagePath eq node.path) ? currentNode.properties['currentPageClasses'] : ''}${' '}
+            ${ showLvl2Pages ? currentNode.properties['hasSubpagesClasses'] : '' }">
         <c:url value="${node.url}" var="nodeUrl"/>
         <a href="${nodeUrl}">${node.displayableName}</a>
         <c:if test="${showLvl2Pages}">
             <${ulTag} class="${currentNode.properties['lvl2ListClasses']}">
             <c:forEach var="child" items="${children}">
-                <${liTag} class="${currentNode.properties['lvl2ItemClasses']}"
-                    ${ (currentPagePath eq node.path) ? currentNode.properties['currentPageClasses'] : ''}>
-
+                <${liTag} class="${currentNode.properties['lvl2ItemClasses']}${' '}
+                    ${ (currentPagePath eq child.path) ? currentNode.properties['currentPageClasses'] : ''}">
                 <c:url value="${child.url}" var="childUrl"/>
                 <a href="${childUrl}">${child.displayableName}</a>
                 </${liTag}>


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15333

## Description

Fix bug of current page classes not showing up on sub-nodes - fixed concatenation syntax 

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
