### PR TITLE
BACKLOG-15320: show description when hovering on HTML code components

### DIFF
--- a/page-builder-components/src/main/resources/common/displayHtml.jsp
+++ b/page-builder-components/src/main/resources/common/displayHtml.jsp
@@ -50,3 +50,15 @@
         </c:choose>
     </c:forEach>
 </c:if>
+
+<c:if test="${renderContext.editMode && not empty currentNode.properties['jcr:description']}">
+  <template:addResources type="css" resources="edit.css" />
+    <div class="jst-description hide">
+        <svg width="2em" height="2em" fill="currentColor" viewBox="0 0 160 160" xmlns="http://www.w3.org/2000/svg" version="1.0">
+           <path d="m80 15c-35.88 0-65 29.12-65 65s29.12 65 65 65 65-29.12 65-65-29.12-65-65-65zm0 10c30.36 0 55 24.64 55 55s-24.64 55-55 55-55-24.64-55-55 24.64-55 55-55z"></path>
+           <path d="m57.373 18.231a9.3834 9.1153 0 1 1 -18.767 0 9.3834 9.1153 0 1 1 18.767 0z" transform="matrix(1.1989 0 0 1.2342 21.214 28.75)"></path>
+           <path d="m90.665 110.96c-0.069 2.73 1.211 3.5 4.327 3.82l5.008 0.1v5.12h-39.073v-5.12l5.503-0.1c3.291-0.1 4.082-1.38 4.327-3.82v-30.813c0.035-4.879-6.296-4.113-10.757-3.968v-5.074l30.665-1.105"></path>
+        </svg>
+        <span>${currentNode.properties['jcr:description'].string}</span>
+    </div>
+</c:if>

--- a/page-builder-components/src/main/resources/css/edit.css
+++ b/page-builder-components/src/main/resources/css/edit.css
@@ -1,0 +1,21 @@
+.jst-description {
+   display: flex;
+   align-items: center;
+   margin: 4px 0;
+   padding: 8px;
+   border-radius: 4px;
+   background-color: #f2f2f2;
+   font-size: 12px;
+}
+
+.jst-description.hide {
+   display: none;
+}
+
+.jst-description svg {
+   margin-right: 4px;
+}
+
+.gwt-HTML:hover .jst-description.hide {
+  display: block;
+}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15320

## Description

When hovering on a HTML code component (file or text), and if this component has a description set (in Content Editor), then we display the description just below the component.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
