### PR TITLE
BACKLOG-15316: order asset files alphabetically

### DIFF
--- a/site-builder/src/main/java/org/jahia/modules/sitebuilder/taglibs/TaglibUtils.java
+++ b/site-builder/src/main/java/org/jahia/modules/sitebuilder/taglibs/TaglibUtils.java
@@ -9,6 +9,7 @@ import org.jahia.services.render.RenderContext;
 import javax.jcr.RepositoryException;
 import javax.jcr.query.Query;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -37,6 +38,7 @@ public final class TaglibUtils {
             String optionalOR = i != 0 ? "or" : "";
             sb.append(String.format(" %s isdescendantnode(file, '%s')", optionalOR, paths.get(i)));
         }
+        sb.append(" order by [j:nodename] asc");
 
         QueryResultWrapper result = renderContext.getMainResource().getNode().getSession().getWorkspace()
                 .getQueryManager().createQuery(sb.toString(), Query.JCR_SQL2).execute();
@@ -77,6 +79,9 @@ public final class TaglibUtils {
                 .collect(Collectors.toList());
 
         minList.addAll(allNotMin);
+
+        //need to re-sort the files by alphabetical order
+        minList.sort(Comparator.comparing(JCRNodeWrapper::getName));
         return minList;
     }
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15316

## Description

Include the files in alphabetical order.
I made the modification in the query, and I had to make it as well in the method that removes duplicates when .min file exist.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
