### PR TITLE
BACKLOG-15374: add support for menu labels, internal and external links to the starterNavMenu

### DIFF
--- a/jahia-starter-template/src/main/resources/sbnt_starterNavMenu/html/starterNavMenu.jsp
+++ b/jahia-starter-template/src/main/resources/sbnt_starterNavMenu/html/starterNavMenu.jsp
@@ -1,6 +1,7 @@
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt"%>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
+<%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
 <%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
 <%--@elvariable id="out" type="java.io.PrintWriter"--%>
 <%--@elvariable id="script" type="org.jahia.services.render.scripting.Script"--%>
@@ -18,7 +19,7 @@
 <c:set var="liTag" value="${navMenuType eq 'list' ? 'li' : 'div'}"/>
 
 <c:set var="navRootPage" value="${jcr:getParentOfType(currentNode, 'jnt:page')}"/>
-<c:set var="navPages" value="${jcr:getChildrenOfType(navRootPage, 'jnt:page')}"/>
+<c:set var="navPages" value="${jcr:getChildrenOfType(navRootPage, 'jmix:navMenuItem')}"/>
 <c:set var="currentPagePath" value="${renderContext.mainResource.node.path}"/>
 
 <c:if test="${not empty navPages}">
@@ -26,21 +27,19 @@
     <nav class="${currentNode.properties['navClasses']}">
     <${ulTag} class="${currentNode.properties['lvl1ListClasses']}">
     <c:forEach var="node" items="${navPages}">
-        <c:set var="children" value="${jcr:getChildrenOfType(node, 'jnt:page')}"/>
+        <c:set var="children" value="${jcr:getChildrenOfType(node, 'jmix:navMenuItem')}"/>
         <c:set var="showLvl2Pages" value="${(not empty children) && currentNode.properties['showLvl2Pages'].boolean}"/>
 
         <${liTag} class="${currentNode.properties['lvl1ItemClasses']}${' '}
             ${ (currentPagePath eq node.path) ? currentNode.properties['currentPageClasses'] : ''}${' '}
             ${ showLvl2Pages ? currentNode.properties['hasSubpagesClasses'] : '' }">
-        <c:url value="${node.url}" var="nodeUrl"/>
-        <a href="${nodeUrl}">${node.displayableName}</a>
+        <template:module node="${node}" view="menuElement" editable="false"/>
         <c:if test="${showLvl2Pages}">
             <${ulTag} class="${currentNode.properties['lvl2ListClasses']}">
             <c:forEach var="child" items="${children}">
                 <${liTag} class="${currentNode.properties['lvl2ItemClasses']}${' '}
                     ${ (currentPagePath eq child.path) ? currentNode.properties['currentPageClasses'] : ''}">
-                <c:url value="${child.url}" var="childUrl"/>
-                <a href="${childUrl}">${child.displayableName}</a>
+                <template:module node="${child}" view="menuElement" editable="false"/>
                 </${liTag}>
             </c:forEach>
             </${ulTag}>


### PR DESCRIPTION


<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15374

## Description
Use jmix:navMenuItem instead of jnt:page to retrieve the elements to display in the navigation menu, so that menu labels, internal and external links appear in the nav menu.
I had to use template:module for the link tag generation to ensure the correct link is generated.

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
