### PR TITLE
BACKLOG-15318: Add 'width:100%' to jahia-template-gxt class

### DIFF
--- a/jahia-starter-template/src/main/import/content/modules/site-builder/files/assets/pageComposerOnly/css/pageComposerOverride.css/pageComposerOverride.css
+++ b/jahia-starter-template/src/main/import/content/modules/site-builder/files/assets/pageComposerOnly/css/pageComposerOverride.css/pageComposerOverride.css
@@ -1,3 +1,3 @@
-.jahia-template-gxt .editmodeArea {
+.jahia-template-gxt {
 	width: 100%;
 }


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->
https://jira.jahia.org/browse/BACKLOG-15318

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Combined existing override and add 'width:100%' to jahia-template-gxt class instead of .jahia-template-gxt .editmodeArea.

