### PR TITLE
BACKLOG-15357: Add page-builder dependency and content restriction

### DIFF
--- a/jahia-starter-template/pom.xml
+++ b/jahia-starter-template/pom.xml
@@ -103,7 +103,7 @@
                 <configuration>
                     <instructions>
                         <Jahia-Module-Type>templatesSet</Jahia-Module-Type>
-                        <Jahia-Depends>default</Jahia-Depends>
+                        <Jahia-Depends>default,page-builder-components</Jahia-Depends>
                     </instructions>
                 </configuration>
             </plugin>

--- a/jahia-starter-template/src/main/import/repository.xml
+++ b/jahia-starter-template/src/main/import/repository.xml
@@ -91,7 +91,7 @@
                <pagecontent jcr:mixinTypes="jmix:systemNameReadonly"
                             jcr:primaryType="jnt:contentList">
                   <header j:limitedAbsoluteAreaEdit="false" jcr:primaryType="jnt:absoluteArea"/>
-                  <pagecontent j:allowedTypes="jmix:pageBuilderComponentMixin"
+                  <pagecontent j:allowedTypes="jnt:htmlCodeAsFile jnt:htmlCodeAsText"
                                jcr:primaryType="jnt:area"/>
                   <footer j:allowedTypes="jmix:droppableContent"
                           j:limitedAbsoluteAreaEdit="false"


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-15357

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Add `Jahia-depends` dependency to `page-builder-components` and add component restriction to only able to add components `jnt:htmlCodeAsFile` and `jnt:htmlCodeAsText`